### PR TITLE
Set sdp_cam2telstate_status to ready after startup

### DIFF
--- a/scripts/cbfsim.py
+++ b/scripts/cbfsim.py
@@ -102,6 +102,10 @@ def prepare_server(server, args):
             server.set_n_dumps(product, args.dumps)
         if args.start:
             server.capture_start(product)
+    if args.telstate is not None:
+        # Consumers may wait for cam2telstate to set its status to 'ready'
+        # before fetching attributes.
+        args.telstate.add('sdp_cam2telstate_status', 'ready')
 
 
 def main():


### PR DESCRIPTION
This is to allow consumers to wait on this telstate sensor before
reading other bits of telstate.
