### PR TITLE
Decrease max packet size for sending

### DIFF
--- a/katcbfsim/stream.py
+++ b/katcbfsim/stream.py
@@ -42,7 +42,7 @@ class SpeadStream(object):
         # Send at a slightly higher rate, to account for overheads, and so
         # that if the sender sends a burst we can catch up with it.
         out_rate = in_rate * 1.05 / n
-        config = spead2.send.StreamConfig(rate=out_rate, max_packet_size=9172)
+        config = spead2.send.StreamConfig(rate=out_rate, max_packet_size=4096)
         self._streams = []
         for i in range(n_streams):
             e = endpoints[i * len(endpoints) // n_streams]


### PR DESCRIPTION
The max packet size is reduced to 4096, to more closely approximate the
MeerKAT CBF. The CBF uses a max _payload_ size of 4096, but spead2
doesn't have an option to limit payload size independently from packet
size.

This will probably be superseded by #4 (which brings a command-line
option to configure it) once it is ready, but this change is made
for now to reduce the packet size below the new SDP MTU of 9000.
