### PR TITLE
Add ?capture-meta command

### DIFF
--- a/katcbfsim/stream.py
+++ b/katcbfsim/stream.py
@@ -206,7 +206,6 @@ class Stream(object):
     """
     def __init__(self, subarray, name, loop=None):
         self._capture_future = None
-        self._metadata_future = None
         self._stop_future = None
         self.name = name
         self.subarray = subarray


### PR DESCRIPTION
Adds a ?capture-meta katcp command that "sends" the metadata (which actually means putting it into telstate), so that this can be separated from starting the actual stream.

This will actually cause telstate to be populated twice, but that's harmless as long as the values don't change.