### PR TITLE
Avoid duplicating antennas

### DIFF
--- a/katcbfsim/stream.py
+++ b/katcbfsim/stream.py
@@ -74,7 +74,10 @@ class Subarray(object):
         self.capturing = 0     # Number of stream that are capturing
 
     def add_antenna(self, antenna):
-        """Add a new antenna to the simulation.
+        """Add a new antenna to the simulation, or replace an existing one.
+
+        If an antenna with the same name exists, it is replaced, otherwise the
+        antenna is appended.
 
         Parameters
         ----------
@@ -88,7 +91,12 @@ class Subarray(object):
         """
         if self.capturing:
             raise CaptureInProgressError('cannot add antennas while capture is in progress')
-        self.antennas.append(antenna)
+        for i in range(len(self.antennas)):
+            if self.antennas[i].name == antenna.name:
+                self.antennas[i] = antenna
+                break
+        else:
+            self.antennas.append(antenna)
 
     def add_source(self, source):
         """Add a new source to the simulation.

--- a/katcbfsim/test/test_server.py
+++ b/katcbfsim/test/test_server.py
@@ -312,3 +312,26 @@ class TestSimulationServer(object):
         yield self.assert_request_fails('^cannot set clock ratio while capture is in progress$', 'clock-ratio', 1.0)
         yield self.assert_request_fails('^cannot set center_frequency while capture is in progress', 'frequency-select', 'beam1', 10000000000)
         yield self.make_request('capture-stop', 'beam1')
+
+    @tornado.gen.coroutine
+    def _get_antenna_descriptions(self):
+        informs = yield self.make_request('antenna-list')
+        raise Return([inform.arguments[0] for inform in informs])
+
+    @async_test
+    @tornado.gen.coroutine
+    def test_replace_antenna(self):
+        """Adding an antenna with a duplicate name replaces the existing one."""
+        yield self._configure_subarray()
+        antennas = yield self._get_antenna_descriptions()
+        assert_equal([
+            'm062, -30:42:47.4, 21:26:38.0, 1035.0, 13.5, -1440.69968823 -2269.26759132 6.0, -0:05:44.7 0 0:00:22.6 -0:09:04.2 0:00:11.9 -0:00:12.8 -0:04:03.5 0 0 -0:01:33.0 0:01:45.6 0 0 0 0 0 -0:00:03.6 -0:00:17.5, 1.22',
+            'm063, -30:42:47.4, 21:26:38.0, 1035.0, 13.5, -3419.58251626 -1606.01510973 2.0, -0:05:44.7 0 0:00:22.6 -0:09:04.2 0:00:11.9 -0:00:12.8 -0:04:03.5 0 0 -0:01:33.0 0:01:45.6 0 0 0 0 0 -0:00:03.6 -0:00:17.5, 1.22'],
+            antennas)
+        # Change the latitude, to check that the old value is replaced
+        yield self.make_request('antenna-add', 'm062, -30:00:00.0, 21:26:38.0, 1035.0, 13.5, -1440.69968823 -2269.26759132 6.0, -0:05:44.7 0 0:00:22.6 -0:09:04.2 0:00:11.9 -0:00:12.8 -0:04:03.5 0 0 -0:01:33.0 0:01:45.6 0 0 0 0 0 -0:00:03.6 -0:00:17.5, 1.22')
+        antennas = yield self._get_antenna_descriptions()
+        assert_equal([
+            'm062, -30:00:00.0, 21:26:38.0, 1035.0, 13.5, -1440.69968823 -2269.26759132 6.0, -0:05:44.7 0 0:00:22.6 -0:09:04.2 0:00:11.9 -0:00:12.8 -0:04:03.5 0 0 -0:01:33.0 0:01:45.6 0 0 0 0 0 -0:00:03.6 -0:00:17.5, 1.22',
+            'm063, -30:42:47.4, 21:26:38.0, 1035.0, 13.5, -3419.58251626 -1606.01510973 2.0, -0:05:44.7 0 0:00:22.6 -0:09:04.2 0:00:11.9 -0:00:12.8 -0:04:03.5 0 0 -0:01:33.0 0:01:45.6 0 0 0 0 0 -0:00:03.6 -0:00:17.5, 1.22'],
+            antennas)


### PR DESCRIPTION
This make configure-subarray-from-telstate idempotent, instead of
duplicating all the antennas each time it is called.