### PR TITLE
Add n_chans_per_substream for correlator product

### DIFF
--- a/katcbfsim/test/test_server.py
+++ b/katcbfsim/test/test_server.py
@@ -226,6 +226,7 @@ class TestSimulationServer(object):
         # 0.5 rounded to nearest acceptable interval
         self._telstate.add.assert_any_call('cbf_int_time', n_accs * 2 * 4096 / 1712000000.0, immutable=True)
         self._telstate.add.assert_any_call('cbf_n_accs', n_accs, immutable=True)
+        self._telstate.add.assert_any_call('cbf_n_chans_per_substream', 512, immutable=True)
         # Use assert_called_with here rather than assert_any_call, to ensure
         # that it is the *last* call.
         self._telstate.add.assert_called_with('sdp_cam2telstate_status', 'ready', immutable=False)
@@ -264,7 +265,7 @@ class TestSimulationServer(object):
         print(self._telstate.add.mock_calls)
         self._telstate.add.assert_any_call('cbf_{}_n_chans'.format(uname), 4096, immutable=False)
         self._telstate.add.assert_any_call(
-            'cbf_{}_n_chans_per_substream'.format(uname), 1024, immutable=False)
+            'cbf_{}_n_chans_per_substream'.format(uname), 1024, immutable=True)
         self._telstate.add.assert_any_call('cbf_{}_spectra_per_heap'.format(uname), 256, immutable=True)
         for i in range(4):   # input
             self._telstate.add.assert_any_call(

--- a/katcbfsim/transport.py
+++ b/katcbfsim/transport.py
@@ -363,6 +363,8 @@ class FXTelstateTransport(CBFTelstateTransport):
         self.sensor(pre + 'bls_ordering', baselines)
         self.sensor(pre + 'int_time', self.stream.accumulation_length)
         self.sensor(pre + 'n_accs', self.stream.n_accs)
+        self.sensor(pre + 'n_chans_per_substream', self.stream.n_channels // self.n_substreams,
+            immutable=True)
 
     def _send_metadata(self):
         super(FXTelstateTransport, self)._send_metadata()
@@ -375,7 +377,7 @@ class BeamformerTelstateTransport(CBFTelstateTransport):
         pre = self._make_prefix(self.stream_name)
         self.sensor(pre + 'n_chans', self.stream.n_channels, immutable=False)
         self.sensor(pre + 'n_chans_per_substream', self.stream.n_channels // self.n_substreams,
-            immutable=False)
+            immutable=True)
         self.sensor(pre + 'spectra_per_heap', self.stream.timesteps)
         for i in range(2 * self.stream.n_antennas):
             self.sensor('{}input{}_weight'.format(pre, i), 1.0, immutable=False)


### PR DESCRIPTION
This is to match the real CBF, and make it available for ingest.