### PR TITLE
Fix substream count when antennas added after destination set

### DIFF
--- a/katcbfsim/server.py
+++ b/katcbfsim/server.py
@@ -233,11 +233,6 @@ class SimulatorServer(katcp.DeviceServer):
 
     def set_destination(self, stream, endpoints, interface=None,
                         n_substreams=None, max_packet_size=None):
-        if n_substreams is None:
-            # Formula used by MeerKAT CBF
-            n_substreams = 4
-            while n_substreams < max(len(endpoints), stream.n_antennas * 4):
-                n_substreams *= 2
         if isinstance(stream, FXStream):
             stream.transport_factories = [
                 transport.FXSpeadTransport.factory(endpoints, interface, n_substreams, max_packet_size)

--- a/katcbfsim/test/test_server.py
+++ b/katcbfsim/test/test_server.py
@@ -226,7 +226,7 @@ class TestSimulationServer(object):
         # 0.5 rounded to nearest acceptable interval
         self._telstate.add.assert_any_call('cbf_int_time', n_accs * 2 * 4096 / 1712000000.0, immutable=True)
         self._telstate.add.assert_any_call('cbf_n_accs', n_accs, immutable=True)
-        self._telstate.add.assert_any_call('cbf_n_chans_per_substream', 512, immutable=True)
+        self._telstate.add.assert_any_call('cbf_n_chans_per_substream', 256, immutable=True)
         # Use assert_called_with here rather than assert_any_call, to ensure
         # that it is the *last* call.
         self._telstate.add.assert_called_with('sdp_cam2telstate_status', 'ready', immutable=False)


### PR DESCRIPTION
Previously the number of substreams was set at the time the capture
destination was set. In the katsdpcontroller-driven workflow, that
occurred before configuring antennas, causing the wrong number of
substreams to be used.

Determining the number of substreams is now deferred to the time the
transport is constructed. For implementation reasons, that also means
that specifying more endpoints than the default number of substreams now
requires the user to explicitly increase the substream count.