### PR TITLE
Incorporate a bandpass shape into the gains

### DIFF
--- a/katcbfsim/stream.py
+++ b/katcbfsim/stream.py
@@ -586,7 +586,7 @@ class FXStream(CBFStream):
         x = np.linspace(0.0, self.n_channels, nx)
         # Set up a mostly flat bandpass with rolloff at the edges, in log-space.
         y = np.zeros(nx)
-        y[-1] = y[0] = np.log10(0.1)    # 10 dB rolloff
+        y[-1] = y[0] = np.log(0.1)    # 10 dB rolloff
         y[:] += rs.normal(scale=0.01, size=y.shape)
         f = scipy.interpolate.interp1d(x, y, kind='cubic', assume_sorted=True)
         bp = f(np.arange(self.n_channels))


### PR DESCRIPTION
It's currently hard-coded. It deliberately messes with certain channels to make it easier to detect mis-placement of channels in the pipeline.

Also includes a fix to actually import katsdptelstate, which was found to be missing when an exception was thrown.