### PR TITLE
Change how configure-subarray-from-telstate gets antennas list

### DIFF
--- a/doc/about.rst
+++ b/doc/about.rst
@@ -173,6 +173,12 @@ a few key options are documented here.
 
    Load antenna descriptions from a file that contains one per line.
 
+.. option:: --cbf-antenna-mask <LIST>
+
+   Comma-separated list of antenna names. They will be given a fake position,
+   which can later be replaced using the
+   :samp:`configure-subarray-from-telstate` katcp request (see below).
+
 .. option:: --cbf-sim-source <DESCRIPTION>, --cbf-sim-source-file <FILENAME>
 
    These are similar, but for sources rather than antennas.
@@ -222,14 +228,12 @@ Mixed katcp and telstate
 ^^^^^^^^^^^^^^^^^^^^^^^^
 If the subarray static properties are not known at the time the simulator
 process is started, they can still be loaded from telstate later, using the
-:samp:`?configure-subarray-from-telstate` request. This takes no parameters,
-and requires that :option:`--telstate` was given on the command line.
+:samp:`?configure-subarray-from-telstate` request. This takes an optional
+parameter, which is a comma-separated list of antenna names, and requires that
+:option:`--telstate` was given on the command line. If no antenna names are
+listed, the names of the antennas configured at startup are used, replacing
+their positions (this is a good match for :opt:`--cbf-antenna-mask`).
 
-This loads additional configuration, which augments or overrides any specified
-in the :attr:`config` dictionary:
-
-- The list of antennas is obtained from
-  ``telstate['config']['antenna_mask']``, which must be a comma-separated list
-  (without whitespace). For an antenna named `name`, the attribute
-  :samp:`{name}_observer` is used to obtain the antenna. It can be specified as
-  either a description string or an antenna object.
+For each antenna named `name`, the attribute :samp:`{name}_observer` is used to
+obtain the antenna. It can be specified as either a description string or an
+antenna object.

--- a/katcbfsim/test/test_server.py
+++ b/katcbfsim/test/test_server.py
@@ -331,16 +331,11 @@ class TestSimulationServer(object):
         # simulate telstate, but the fakeredis telstate is a singleton
         # and so leaks state across tests.
         telstate = {
-            'config': {'antenna_mask': 'm062,m063'},
             'm062_observer': M062_DESCRIPTION,
             'm063_observer': M063_DESCRIPTION
         }
-        telstate = katsdptelstate.TelescopeState()
-        telstate.add('config', {'antenna_mask': 'm062,m063'}, immutable=True)
-        telstate.add('m062_observer', M062_DESCRIPTION, immutable=True)
-        telstate.add('m063_observer', M063_DESCRIPTION, immutable=True)
         self._server._telstate = telstate
-        yield self.make_request('configure-subarray-from-telstate')
+        yield self.make_request('configure-subarray-from-telstate', 'm062,m063')
         antennas = yield self._get_antenna_descriptions()
         assert_equal([M062_DESCRIPTION, M063_DESCRIPTION], antennas)
 
@@ -348,10 +343,9 @@ class TestSimulationServer(object):
     @tornado.gen.coroutine
     def test_configure_subarray_from_telstate_missing_antenna(self):
         telstate = {
-            'config': {'antenna_mask': 'm062,m063'},
             'm062_observer': M062_DESCRIPTION
         }
         self._server._telstate = telstate
         yield self.assert_request_fails(
             '^Antenna description for m063 not found$',
-            'configure-subarray-from-telstate')
+            'configure-subarray-from-telstate', 'm062,m063')


### PR DESCRIPTION
It previously looked in telstate['config']['antenna_mask']. With the
change to a more flexible subarray configuration, it's less clear that
there will be a single global antenna list. Thus, two alternatives are
introduced:
- an optional argument to the katcp request, explicitly giving an
  antenna list. This is mostly used by the test suite.
- if the optional argument is not given, the existing antennas are
  replaced. This should be largely backwards-compatible, because the
  argument parser picks up telstate['config']['antenna_mask'] and uses
  it to generate fake antennas (with no particular position).