### PR TITLE
Convert frequency variables to float

### DIFF
--- a/katcbfsim/server.py
+++ b/katcbfsim/server.py
@@ -97,7 +97,7 @@ class SimulatorServer(katcp.DeviceServer):
             stream.set_telstate(self._telstate)
         self._streams[stream.name] = stream
         self._stream_sensors[stream] = {
-            'bandwidth': Sensor.integer(
+            'bandwidth': Sensor.float(
                 '{}.bandwidth'.format(stream.name),
                 'The bandwidth currently configured for the data stream',
                 'Hz', default=stream.bandwidth, initial_status=Sensor.NOMINAL),
@@ -105,7 +105,7 @@ class SimulatorServer(katcp.DeviceServer):
                 '{}.channels'.format(stream.name),
                 'The number of channels of the channelised data stream',
                 '', default=stream.n_channels, initial_status=Sensor.NOMINAL),
-            'centerfrequency': Sensor.integer(
+            'centerfrequency': Sensor.float(
                 '{}.centerfrequency'.format(stream.name),
                 'The center frequency for the data stream', 'Hz')
         }
@@ -122,7 +122,7 @@ class SimulatorServer(katcp.DeviceServer):
         self._add_stream(stream)
         return stream
 
-    @request(Str(), Int(), Int(), Int(), Int(), Int(optional=True))
+    @request(Str(), Float(), Float(), Float(), Int(), Int(optional=True))
     @return_reply()
     def request_stream_create_correlator(
             self, sock, name, adc_rate, center_frequency, bandwidth, n_channels, n_substreams=None):
@@ -132,11 +132,11 @@ class SimulatorServer(katcp.DeviceServer):
         ----------
         name : str
             Name for the new stream (must be unique)
-        adc_rate : int
+        adc_rate : float
             Simulated ADC clock rate, in Hz
-        center_frequency : int
+        center_frequency : float
             Sky frequency of the center of the band, in Hz
-        bandwidth : int
+        bandwidth : float
             Bandwidth of all channels in the stream, in Hz
         n_channels : int
             Number of channels in the stream
@@ -152,7 +152,7 @@ class SimulatorServer(katcp.DeviceServer):
         self.add_fx_stream(name, adc_rate, center_frequency, bandwidth, n_channels, n_substreams)
         return 'ok',
 
-    @request(Str(), Int(), Int(), Int(), Int(), Int(), Int(), Int())
+    @request(Str(), Float(), Float(), Float(), Int(), Int(), Int(), Int())
     @return_reply()
     def request_stream_create_beamformer(
             self, sock, name, adc_rate, center_frequency, bandwidth, n_channels,
@@ -231,7 +231,7 @@ class SimulatorServer(katcp.DeviceServer):
     def set_sync_time(self, timestamp):
         self._subarray.sync_time = katpoint.Timestamp(timestamp)
 
-    @request(Int())
+    @request(Float())
     @return_reply()
     @_stream_exceptions
     def request_sync_time(self, sock, timestamp):
@@ -305,7 +305,7 @@ class SimulatorServer(katcp.DeviceServer):
         # TODO: get the simulated timestamp from the stream
         self._stream_sensors[stream]['centerfrequency'].set_value(frequency)
 
-    @request(Str(), Int())
+    @request(Str(), Float())
     @return_reply()
     @_stream_exceptions
     @_stream_request

--- a/katcbfsim/stream.py
+++ b/katcbfsim/stream.py
@@ -77,8 +77,7 @@ class Subarray(object):
         Target. This determines the phase center for the simulation (and
         eventually the center for the beam model as well). Mutable.
     sync_time : :class:`katpoint.Timestamp`
-        Start time for the simulated capture. When set, it is truncated to a
-        whole number of seconds. Stream-immutable.
+        Start time for the simulated capture. Stream-immutable.
     gain : float
         Expected output visibility value, per Jansky per Hz per second.
         Capture-immutable.
@@ -167,7 +166,7 @@ class Subarray(object):
     def sync_time(self, value):
         if self.streams:
             raise CaptureInProgressError('cannot set sync time after creating a stream')
-        self._sync_time = katpoint.Timestamp(int(value.secs))
+        self._sync_time = katpoint.Timestamp(value.secs)
 
     @property
     def gain(self):
@@ -378,11 +377,11 @@ class CBFStream(Stream):
         Subarray corresponding to this stream
     name : str
         Name for this stream (used by katcp)
-    adc_rate : int
+    adc_rate : float
         Simulated ADC clock rate, in Hz
-    center_frequency : int
+    center_frequency : float
         Sky frequency of the center of the band, in Hz
-    bandwidth : int
+    bandwidth : float
         Bandwidth of all channels in the stream, in Hz
     n_channels : int
         Number of channels in the stream
@@ -394,11 +393,11 @@ class CBFStream(Stream):
 
     Attributes
     ----------
-    adc_rate : int
+    adc_rate : float
         Simulated ADC clock rate, in Hz
-    center_frequency : int
+    center_frequency : float
         Sky frequency of the center of the band, in Hz
-    bandwidth : int
+    bandwidth : float
         Bandwidth of all channels in the stream, in Hz
     n_channels : int
         Number of channels in the stream
@@ -406,7 +405,7 @@ class CBFStream(Stream):
         Number of substreams (X/B-engines)
     n_dumps : int
         If not ``None``, limits the number of dumps that will be done
-    scale_factor_timestamp : int
+    scale_factor_timestamp : float
         Number of timestamp increments per second
 
     Raises
@@ -459,9 +458,9 @@ class CBFStream(Stream):
     def _instrument_sensors(self, telstate):
         pre = self._make_prefix(None)   # instrument names not used yet
         # Only the sensors captured by cam2telstate are simulated
-        self.sensor(telstate, pre + 'adc_sample_rate', float(self.adc_rate))
-        self.sensor(telstate, pre + 'bandwidth', float(self.bandwidth))
-        self.sensor(telstate, pre + 'scale_factor_timestamp', float(self.scale_factor_timestamp))
+        self.sensor(telstate, pre + 'adc_sample_rate', self.adc_rate)
+        self.sensor(telstate, pre + 'bandwidth', self.bandwidth)
+        self.sensor(telstate, pre + 'scale_factor_timestamp', self.scale_factor_timestamp)
         self.sensor(telstate, pre + 'sync_time', self.subarray.sync_time.secs)
         self.sensor(telstate, pre + 'n_inputs', 2 * self.n_antennas)
 
@@ -477,7 +476,7 @@ class CBFStream(Stream):
         self.sensor(telstate, pre + 'center_freq', float(self.center_frequency))
         self.sensor(telstate, pre + 'n_chans', self.n_channels)
         self.sensor(telstate, pre + 'ticks_between_spectra',
-                    self.n_channels * self.scale_factor_timestamp // self.bandwidth)
+                    int(round(self.n_channels * self.scale_factor_timestamp / self.bandwidth)))
 
     def set_telstate(self, telstate):
         """Populate telstate with simulated sensors for the stream.
@@ -501,11 +500,11 @@ class FXStream(CBFStream):
         Subarray corresponding to this stream
     name : str
         Name for this stream (used by katcp)
-    adc_rate : int
+    adc_rate : float
         Simulated ADC clock rate, in Hz
-    center_frequency : int
+    center_frequency : float
         Sky frequency of the center of the band, in Hz
-    bandwidth : int
+    bandwidth : float
         Bandwidth of all channels in the stream, in Hz
     n_channels : int
         Number of channels in the stream
@@ -785,11 +784,11 @@ class BeamformerStream(CBFStream):
         Subarray corresponding to this stream
     name : str
         Name for this stream (used by katcp)
-    adc_rate : int
+    adc_rate : float
         Simulated ADC clock rate, in Hz
-    center_frequency : int
+    center_frequency : float
         Sky frequency of the center of the band, in Hz
-    bandwidth : int
+    bandwidth : float
         Bandwidth of all channels in the stream, in Hz
     n_channels : int
         Number of channels in the stream

--- a/katcbfsim/transport.py
+++ b/katcbfsim/transport.py
@@ -150,8 +150,8 @@ class FXSpeadTransport(CBFSpeadTransport):
         substream_channels = self.stream.n_channels // self.stream.n_substreams
         vis_view = vis.reshape(*shape)
         futures = []
-        timestamp = dump_index * self.stream.n_accs * self.stream.n_channels * \
-                self.stream.scale_factor_timestamp // self.stream.bandwidth
+        timestamp = int(dump_index * self.stream.n_accs * self.stream.n_channels
+                        * self.stream.scale_factor_timestamp / self.stream.bandwidth)
         # Truncate timestamp to the width of the field it is in
         timestamp = timestamp & ((1 << self._flavour.heap_address_bits) - 1)
         for i, substream in enumerate(self._substreams):
@@ -237,8 +237,8 @@ class BeamformerSpeadTransport(CBFSpeadTransport):
             self._last_metadata = index
             yield From(self.send_metadata())
         substream_channels = self.stream.n_channels // self.stream.n_substreams
-        timestamp = index * self.stream.timesteps * self.stream.n_channels * \
-                self.stream.scale_factor_timestamp // self.stream.bandwidth
+        timestamp = int(index * self.stream.timesteps * self.stream.n_channels * \
+                self.stream.scale_factor_timestamp / self.stream.bandwidth)
         # Truncate timestamp to the width of the field it is in
         timestamp = timestamp & ((1 << self._flavour.heap_address_bits) - 1)
         futures = []

--- a/scripts/cbfsim.py
+++ b/scripts/cbfsim.py
@@ -138,13 +138,13 @@ def main():
     parser.add_argument('--start', action='store_true', help='Start the defined streams')
     parser.add_argument('--dumps', type=int, help='Set finite number of dumps to produce for pre-configured streams [infinite]')
     parser.add_argument('--cbf-channels', type=int, default=32768, metavar='N', help='Number of channels [%(default)s]')
-    parser.add_argument('--cbf-adc-sample-rate', type=int, default=1712000000, metavar='HZ', help='ADC rate [%(default)s]'),
-    parser.add_argument('--cbf-bandwidth', type=int, default=856000000, metavar='HZ', help='Bandwidth [%(default)s]')
-    parser.add_argument('--cbf-center-freq', type=int, default=1284000000, metavar='HZ', help='Sky center frequency [%(default)s]')
+    parser.add_argument('--cbf-adc-sample-rate', type=float, default=1712000000.0, metavar='HZ', help='ADC rate [%(default)s]'),
+    parser.add_argument('--cbf-bandwidth', type=float, default=856000000.0, metavar='HZ', help='Bandwidth [%(default)s]')
+    parser.add_argument('--cbf-center-freq', type=float, default=1284000000.0, metavar='HZ', help='Sky center frequency [%(default)s]')
     parser.add_argument('--cbf-spead', type=katsdptelstate.endpoint.endpoint_list_parser(7148), metavar='ENDPOINT', default='127.0.0.1:7148', help='destination for CBF output [%(default)s]')
     parser.add_argument('--cbf-interface', metavar='INTERFACE', help='Network interface on which to send data [auto]')
     parser.add_argument('--cbf-ibv', action='store_true', help='Use ibverbs for acceleration (requires --cbf-interface)')
-    parser.add_argument('--cbf-sync-time', type=int, metavar='TIME', help='Sync time as UNIX timestamp [now]')
+    parser.add_argument('--cbf-sync-time', type=float, metavar='TIME', help='Sync time as UNIX timestamp [now]')
     parser.add_argument('--cbf-int-time', type=float, metavar='TIME', default=0.5, help='Integration time in seconds [%(default)s]')
     parser.add_argument('--cbf-substreams', type=int, metavar='N', help='Number of substreams (X/B-engines) in simulated CBF [auto]')
     parser.add_argument('--cbf-antenna', dest='cbf_antennas', type=parse_antenna, action='append', default=[], metavar='DESCRIPTION', help='Specify an antenna (can be used multiple times)')


### PR DESCRIPTION
Bandwidth, center frequency and ADC sample rate are now handled as float
rather than integer. This was triggered by katsdpcontroller passing us
floats in telstate, which broke things, but it also makes katcbfsim more
flexible. The sync time is also changed to handle floats without
truncation.