### PR TITLE
Push command-line antennas into telstate

### DIFF
--- a/doc/about.rst
+++ b/doc/about.rst
@@ -232,8 +232,12 @@ process is started, they can still be loaded from telstate later, using the
 parameter, which is a comma-separated list of antenna names, and requires that
 :option:`--telstate` was given on the command line. If no antenna names are
 listed, the names of the antennas configured at startup are used, replacing
-their positions (this is a good match for :opt:`--cbf-antenna-mask`).
+their positions (this is a good match for :opt:`--cbf-antenna-names`).
 
 For each antenna named `name`, the attribute :samp:`{name}_observer` is used to
 obtain the antenna. It can be specified as either a description string or an
 antenna object.
+
+This flow can also be used in the opposite direction: antennas configured on
+the command line with :opt:`--cbf-antenna` or :opt:`--cbf-antenna-file` are
+stored into telstate as :samp:`{name}_observer`.

--- a/scripts/cbfsim.py
+++ b/scripts/cbfsim.py
@@ -61,17 +61,23 @@ class TelstateSubarray(Subarray):
 
 def prepare_server(server, args):
     """Do server configuration specified by command-line configuration"""
+    def add_antenna(descr, add_to_telstate=True):
+        antenna = katpoint.Antenna(descr)
+        server.add_antenna(antenna)
+        if add_to_telstate and args.telstate is not None:
+            args.telstate.add(antenna.name + '_observer', antenna.description, immutable=True)
+
     # Do the fake ones first, so that real values can replace them
     if args.antenna_mask is not None:
         for name in args.antenna_mask.split(','):
             descr = name + ', 0:00:00.0, 00:00:00.0, 0.0, 0.0, , , 1.0'
-            server.add_antenna(katpoint.Antenna(descr))
+            add_antenna(descr, False)
     for antenna in args.cbf_antennas:
-        server.add_antenna(katpoint.Antenna(antenna['description']))
+        add_antenna(antenna['description'])
     if args.cbf_antenna_file is not None:
         with open(args.cbf_antenna_file) as f:
             for line in f:
-                server.add_antenna(katpoint.Antenna(line))
+                add_antenna(line)
     for source in args.cbf_sim_sources:
         server.add_source(Source(source['description']))
     if args.cbf_sim_source_file is not None:


### PR DESCRIPTION
This will facilitate having antenna information flow from kattelmod ->
master controller -> cbfsim -> telstate -> cal during product
configuration, so that cal doesn't need to delay getting antenna
information.