### PR TITLE
Make bandwidth a per-stream attr in telstate

### DIFF
--- a/katcbfsim/stream.py
+++ b/katcbfsim/stream.py
@@ -525,7 +525,6 @@ class CBFStream(Stream):
     def _instrument_sensors(self, view):
         # Only the sensors captured by cam2telstate are simulated
         self.sensor(view, 'adc_sample_rate', self.adc_rate)
-        self.sensor(view, 'bandwidth', self.bandwidth)
         self.sensor(view, 'scale_factor_timestamp', self.scale_factor_timestamp)
         self.sensor(view, 'sync_time', self.subarray.sync_time.secs)
         self.sensor(view, 'n_inputs', 2 * self.n_antennas)
@@ -538,6 +537,7 @@ class CBFStream(Stream):
             self.sensor(view, input_pre + 'delay_ok', True, immutable=False)
             self.sensor(view, input_pre + 'eq', [200 + 0j], immutable=False)
             self.sensor(view, input_pre + 'fft0_shift', 32767, immutable=False)
+        self.sensor(view, 'bandwidth', self.bandwidth)
         self.sensor(view, 'center_freq', float(self.center_frequency))
         self.sensor(view, 'n_chans', self.n_channels)
         self.sensor(view, 'ticks_between_spectra',
@@ -867,6 +867,7 @@ class FXStream(CBFStream):
                         name1 = self.subarray.antennas[i].name + pol1
                         name2 = self.subarray.antennas[j].name + pol2
                         baselines.append((name1, name2))
+        self.sensor(view, 'bandwidth', self.bandwidth)
         self.sensor(view, 'bls_ordering', baselines)
         self.sensor(view, 'int_time', self.accumulation_length)
         self.sensor(view, 'n_accs', self.n_accs)
@@ -999,6 +1000,7 @@ class BeamformerStream(CBFStream):
                     await transport.close()
 
     def _tied_array_channelised_voltage_sensors(self, view):
+        self.sensor(view, 'bandwidth', self.bandwidth)
         self.sensor(view, 'n_chans', self.n_channels, immutable=False)
         self.sensor(view, 'n_chans_per_substream', self.n_channels // self.n_substreams)
         self.sensor(view, 'spectra_per_heap', self.timesteps)

--- a/katcbfsim/test/test_server.py
+++ b/katcbfsim/test/test_server.py
@@ -199,7 +199,6 @@ class TestSimulationServer(asynctest.TestCase):
     def _check_common_telstate(self):
         instrument_view = self._telstate.view('i0', exclusive=True)
         self._check_attribute(instrument_view, 'adc_sample_rate', 1712000000.0)
-        self._check_attribute(instrument_view, 'bandwidth', 856000000.0)
         self._check_attribute(instrument_view, 'n_inputs', 4)
         self._check_attribute(instrument_view, 'scale_factor_timestamp', 1712000000)
         self._check_attribute(instrument_view, 'sync_time', mock.ANY)
@@ -244,6 +243,7 @@ class TestSimulationServer(asynctest.TestCase):
         self._check_common_telstate()
         n_accs = 408 * 256   # Gives nearest to 0.5s
         view = self._telstate.view('i0_baseline_correlation_products')
+        self._check_attribute(view, 'bandwidth', 856000000.0)
         self._check_attribute(view, 'bls_ordering', bls_ordering)
         # 0.5 rounded to nearest acceptable interval
         self._check_attribute(view, 'int_time', n_accs * 2 * 4096 / 1712000000.0)
@@ -279,6 +279,7 @@ class TestSimulationServer(asynctest.TestCase):
         self._check_common_telstate()
         view = self._telstate.view(uname)
         self._check_sensor(view, 'n_chans', 4096)
+        self._check_attribute(view, 'bandwidth', 856000000.0)
         self._check_attribute(view, 'n_chans_per_substream', 1024)
         self._check_attribute(view, 'spectra_per_heap', 256)
         for i in range(4):   # input


### PR DESCRIPTION
It was per-instrument, but SR-1319 will change it to be sourced per
stream.