### PR TITLE
Add --cbf-int-time argument reflect in telescope state

### DIFF
--- a/katcbfsim/server.py
+++ b/katcbfsim/server.py
@@ -138,7 +138,7 @@ class SimulatorServer(aiokatcp.DeviceServer):
     async def request_stream_create_correlator(
             self, ctx: RequestContext,
             name: str, adc_rate: float, center_frequency: float, bandwidth: float,
-            n_channels: int, n_substreams: int = None) -> None:
+            n_channels: int, n_substreams: int = None, accumulation_length: float = None) -> None:
         """Create a new simulated correlator stream
 
         Parameters
@@ -155,6 +155,8 @@ class SimulatorServer(aiokatcp.DeviceServer):
             Number of channels in the stream
         n_substreams : int, optional
             Number of substreams (X engines)
+        accumulation_length : float, optional
+            Approximate integration time (rounded by the implementation)
         """
         if name in self._streams:
             raise FailReply('stream {} already exists'.format(name))
@@ -162,7 +164,8 @@ class SimulatorServer(aiokatcp.DeviceServer):
             raise FailReply('cannot add a stream while halting')
         if self._context is None:
             raise FailReply('no device context available')
-        self.add_fx_stream(name, adc_rate, center_frequency, bandwidth, n_channels, n_substreams)
+        self.add_fx_stream(name, adc_rate, center_frequency, bandwidth, n_channels,
+                           n_substreams, accumulation_length)
 
     async def request_stream_create_beamformer(
             self, ctx: RequestContext,

--- a/katcbfsim/stream.py
+++ b/katcbfsim/stream.py
@@ -593,6 +593,9 @@ class FXStream(CBFStream):
         Number of channels in the stream
     n_substreams : int
         Number of substreams (X-engines)
+    accumulation_length : float
+        Approximate simulated integration time in seconds. It will be rounded
+        to the nearest supported value.
     loop : :class:`asyncio.BaseEventLoop`, optional
         Event loop for coroutines
 
@@ -611,11 +614,14 @@ class FXStream(CBFStream):
         indirectly by writing to :attr:`accumulation_length`.
     """
     def __init__(self, context, subarray, name, adc_rate,
-                 center_frequency, bandwidth, n_channels, n_substreams, loop=None):
+                 center_frequency, bandwidth, n_channels, n_substreams,
+                 accumulation_length=None, loop=None):
         super(FXStream, self).__init__(subarray, name, adc_rate, center_frequency,
                                        bandwidth, n_channels, n_substreams, loop)
         self.context = context
-        self.accumulation_length = 0.5
+        if accumulation_length is None:
+            accumulation_length = 0.5
+        self.accumulation_length = accumulation_length
         self.sefd = 400.0   # Jansky
         self.seed = 1
 

--- a/scripts/cbfsim.py
+++ b/scripts/cbfsim.py
@@ -97,8 +97,7 @@ def prepare_server(server, args):
         stream = server.add_fx_stream(
             args.create_fx_stream,
             args.cbf_adc_sample_rate, args.cbf_center_freq, args.cbf_bandwidth,
-            args.cbf_channels, args.cbf_substreams)
-        server.set_accumulation_length(stream, args.cbf_int_time)
+            args.cbf_channels, args.cbf_substreams, args.cbf_int_time)
         server.set_destination(stream, args.cbf_spead, ifaddr, args.cbf_ibv,
                                args.max_packet_size)
         if args.dumps:


### PR DESCRIPTION
Set the accumulation length during construction of the stream, rather
than in a separate step that happens too late to affect telstate.

Fixes SR-1325.