### PR TITLE
Repeat item pointers in every SPEAD packet

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ pytz
 redis
 scipy
 six
-spead2
+spead2==1.11.1     # Need newer version than katsdpdockerbase currently provides
 git+ssh://git@github.com/ska-sa/katpoint#egg=katpoint
 git+ssh://git@github.com/ska-sa/katsdptelstate#egg=katsdptelstate
 git+ssh://git@github.com/ska-sa/katsdpservices#egg=katsdpservices

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     scripts=['scripts/cbfsim.py'],
     setup_requires=['katversion'],
     install_requires=[
-        'aiokatcp', 'spead2>=1.5.0', 'katpoint', 'numpy', 'h5py',
+        'aiokatcp', 'spead2>=1.11.1', 'katpoint', 'numpy', 'h5py',
         'katsdpsigproc[CUDA]', 'katsdptelstate', 'netifaces', 'numba',
         'katsdpservices'],
     tests_require=tests_require,


### PR DESCRIPTION
This makes the data stream more similar to the real MeerKAT CBF. It's
also necessary for the beamformer engineering capture to work once
ska-sa/katsdpingest#290 is merged.