### PR TITLE
Update some sensors to match M1000-0001-002 Rev 6

### DIFF
--- a/katcbfsim/stream.py
+++ b/katcbfsim/stream.py
@@ -1010,11 +1010,9 @@ class BeamformerStream(CBFStream):
 
     def _tied_array_channelised_voltage_sensors(self, view):
         self.sensor(view, 'bandwidth', self.bandwidth)
-        self.sensor(view, 'n_chans', self.n_channels, immutable=False)
         self.sensor(view, 'n_chans_per_substream', self.n_channels // self.n_substreams)
         self.sensor(view, 'spectra_per_heap', self.timesteps)
-        for i in range(2 * self.n_antennas):
-            self.sensor(view, 'input{}_weight'.format(i), 1.0, immutable=False)
+        self.sensor(view, 'weight', str([1.0] * (2 * self.n_antennas)), immutable=False)
 
     def set_telstate(self, telstate):
         super(BeamformerStream, self).set_telstate(telstate)

--- a/katcbfsim/test/test_server.py
+++ b/katcbfsim/test/test_server.py
@@ -278,12 +278,10 @@ class TestSimulationServer(asynctest.TestCase):
         assert_true(_current_transport.closed)
         self._check_common_telstate()
         view = self._telstate.view(uname)
-        self._check_sensor(view, 'n_chans', 4096)
         self._check_attribute(view, 'bandwidth', 856000000.0)
         self._check_attribute(view, 'n_chans_per_substream', 1024)
         self._check_attribute(view, 'spectra_per_heap', 256)
-        for i in range(4):   # input
-            self._check_sensor(view, 'input{}_weight'.format(i), 1.0)
+        self._check_sensor(view, 'weight', '[1.0, 1.0, 1.0, 1.0]')
 
     async def test_beamformer_capture(self):
         """Create a beamformer target, start it, and stop it again"""


### PR DESCRIPTION
The beam inputs weights are now unified into a single sensor with an
array value, and the beam n_chans sensor is gone (now the upstream
array-channelised-voltage stream indicates the number of channels).

Closes SR-1520.