### PR TITLE
Remove stale dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,7 @@ async-timeout
 decorator
 fakeredis
 future
-futures
 h5py
-ipaddress
 katversion
 llvmlite
 Mako
@@ -16,7 +14,6 @@ netifaces
 numba
 numpy
 pandas
-pkginfo
 py
 pycuda
 pyephem


### PR DESCRIPTION
pkginfo used to be used by katversion, but no longer, and the others are
Python 2 backports.