### PR TITLE
Update requirements to match katsdpdockerbase update

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -14,6 +14,12 @@ pytz
 requests
 snowballstemmer
 Sphinx
+sphinxcontrib-applehelp
+sphinxcontrib-devhelp
+sphinxcontrib-htmlhelp
+sphinxcontrib-jsmath
+sphinxcontrib-qthelp
+sphinxcontrib-serializinghtml
 sphinxcontrib-websupport
 sphinx-rtd-theme
 urllib3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ aiokatcp
 appdirs
 async-timeout
 decorator
+ephem
 future
 h5py
 katversion

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ aiokatcp
 appdirs
 async-timeout
 decorator
-fakeredis
 future
 h5py
 katversion
@@ -14,11 +13,9 @@ netifaces
 numba
 numpy
 pandas
-py
 pycuda
 pyephem
 pygelf
-pytest
 python-dateutil
 pytools
 pytz

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,9 +1,3 @@
-argparse       # required by unittest2
-asynctest==0.10.0
+asynctest
 coverage
-linecache2     # required by unittest2
-mock           # required by katsdpsigproc.test
 nose
-pbr            # required by mock
-traceback2     # required by unittest2
-unittest2      # required by katsdpsigproc.test


### PR DESCRIPTION
Update requirements to match katsdpdockerbase update

This should be merged together with ska-sa/katsdpdockerbase#46. It may
currently fail to build until that branch is merged.