### PR TITLE
Use big endian for visibilities

### DIFF
--- a/katcbfsim/rime.py
+++ b/katcbfsim/rime.py
@@ -71,7 +71,7 @@ class RimeTemplate(object):
                                      '-34:00:00', '20:00:00', '0.0', 10.0, (i, 0, 0))
                     for i in range(n_antennas)]
         # The values are irrelevant, we just need the memory to be there.
-        out = accel.DeviceArray(context, (n_channels, n_baselines, 2, 2, 2), np.int32)
+        out = accel.DeviceArray(context, (n_channels, n_baselines, 2, 2, 2), '>i4')
 
         def generate_predict(predict_wgs):
             tuning = dict(predict_wgs=predict_wgs, sample_wgs=256, sample_rows=64)
@@ -133,7 +133,7 @@ class Rime(accel.Operation):
         self.phase_center = katpoint.construct_radec_target(0, 0)
         self.position = None
         _2 = accel.Dimension(2, exact=True)
-        self.slots['out'] = accel.IOSlot((n_channels, n_baselines, _2, _2, _2), np.int32)
+        self.slots['out'] = accel.IOSlot((n_channels, n_baselines, _2, _2, _2), '>i4')
         self.predict_kernel = template.predict_program.get_kernel('predict')
         self.sample_kernel = template.sample_program.get_kernel('sample')
         # Set up the inverse wavelength lookup table

--- a/katcbfsim/sample.mako
+++ b/katcbfsim/sample.mako
@@ -22,6 +22,22 @@ DEVICE_FN int2 to_int(cplex a)
 #endif
 }
 
+DEVICE_FN int2 to_big_endian(int2 a)
+{
+#ifdef __OPENCL_VERSION__
+# error "Not yet implemented for OpenCL"
+#else
+    /* The CUDA programming guide says "The NVIDIA GPU architecture uses a
+     * little-endian representation," so there is no need to check the
+     * endianness.
+     */
+    int2 out;
+    out.x = __byte_perm(a.x, 0, 0x0123);
+    out.y = __byte_perm(a.y, 0, 0x0123);
+    return out;
+#endif
+}
+
 typedef union
 {
     jones in;
@@ -140,7 +156,7 @@ KERNEL void sample(
         ijones quant;
         for (int i = 0; i < 2; i++)
             for (int j = 0; j < 2; j++)
-                quant.m[i][j] = to_int(sample.m[i][j]);
+                quant.m[i][j] = to_big_endian(to_int(sample.m[i][j]));
         data[data_idx].out = quant;
     }
 }

--- a/katcbfsim/test/test_rime.py
+++ b/katcbfsim/test/test_rime.py
@@ -91,7 +91,7 @@ class TestRime(object):
         raw = allocator.allocate_raw(n_channels * n_baselines * 4 * 8)
         # in_data and out_data both alias raw, since _run_sample runs in-place
         in_data = allocator.allocate((n_channels, n_baselines, 2, 2), np.complex64, raw=raw)
-        out_data = allocator.allocate((n_channels, n_baselines, 2, 2, 2), np.int32, raw=raw)
+        out_data = allocator.allocate((n_channels, n_baselines, 2, 2, 2), '>i4', raw=raw)
         delays = np.array([3.0, -4.0, 6.0])           # In m, after phasing
         stokes = (10.0, 7.0, 5.0, 4.0)                # In Jansky
         B = np.matrix([

--- a/katcbfsim/transport.py
+++ b/katcbfsim/transport.py
@@ -190,7 +190,7 @@ class FXSpeadTransport(CBFSpeadTransport):
             '(n_bls given by SPEAD Id=0x1008). '
             'Each value is a complex number - two (real and imaginary) signed integers.',
             (self.stream.n_channels // self.stream.n_substreams, self.stream.n_baselines * 4, 2),
-            np.int32)
+            np.dtype('>i4'))
 
     async def send(self, vis, dump_index):
         if (dump_index - self._last_metadata) * self.stream.accumulation_length >= 5.0:


### PR DESCRIPTION
The real MeerKAT CBF produces visibilities in big endian, so do the
same. For efficiency, the visibilities are converted to big endian on
the GPU as part of the sampling process.

Closes SPR1-138.