### PR TITLE
Suppress some flake8 E741 warnings

### DIFF
--- a/katcbfsim/rime.py
+++ b/katcbfsim/rime.py
@@ -34,7 +34,7 @@ def _rotate_gains(G, P, out):
     for i in range(G.shape[0]):
         for j in range(G.shape[1]):
             for k in range(2):
-                for l in range(2):
+                for l in range(2):  # noqa: E741
                     out[i, j, k, l] = G[i, j, k, 0] * P[j, 0, l] + G[i, j, k, 1] * P[j, 1, l]
 
 

--- a/katcbfsim/test/test_rime.py
+++ b/katcbfsim/test/test_rime.py
@@ -166,7 +166,7 @@ class TestRime(object):
                             np.conj(device_samples[channel, baseline_index, 1, 0, ...]),
                             "Autocorrelation is not Hermitian")
                     for k in range(2):
-                        for l in range(2):
+                        for l in range(2):  # noqa: E741
                             cur = samples[2 * i + k, 2 * j + l, ...]
                             ds = device_samples[channel, baseline_index, k, l, ...]
                             cur = np.c_[cur.real, cur.imag].T


### PR DESCRIPTION
The newer flake8 doesn't like variables called 'l'.