### PR TITLE
Make things work with Docker >= 20.10.14

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/PyCQA/flake8
   rev: 3.9.2
   hooks:
     - id: flake8

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY --from=build --chown=kat:kat /home/kat/ve3 /home/kat/ve3
 ENV PATH="$PATH_PYTHON3" VIRTUAL_ENV="$VIRTUAL_ENV_PYTHON3"
 # Allow raw packets (for ibverbs raw QPs)
 USER root
-RUN setcap cap_net_raw+i /usr/local/bin/capambel
+RUN setcap cap_net_raw+p /usr/local/bin/capambel
 USER kat
 
 # Expose katcp port


### PR DESCRIPTION
This version [changed](https://github.com/moby/moby/issues/43420) the behaviour so that no capabilities are inherited. It's thus insufficient for capambel to have +i - it needs +p.