### PR TITLE
Further fallout of ska-sa/katsdpdockerbase#112

### DIFF
--- a/katcbfsim/test/test_rime.py
+++ b/katcbfsim/test/test_rime.py
@@ -184,7 +184,7 @@ class TestRime(object):
                                 expected = expected[0:1]
                             result = boxm_test(cur, ds)
                             assert_greater(result.pvalue, threshold1)
-                            result = scipy.stats.ttest_1samp(ds, expected, axis=1)
+                            result = scipy.stats.ttest_1samp(ds, np.c_[expected], axis=1)
                             for p in np.atleast_1d(result.pvalue):
                                 assert_greater(p, threshold1)
                     baseline_index += 1


### PR DESCRIPTION
This is to make tests pass. As of 1.10.1, `scipy.stats.ttest_1samp` requires `popmean.shape[axis]` to be exactly `1`: https://github.com/scipy/scipy/commit/709a01f4b238cc039d8bde8d984af2c547bea98b#diff-c850dba4f9919cabafa6e3ffbc1d0c61cf315d1e06755a867317fd891f9e2aaa